### PR TITLE
DAS-76 JSON 표기법 변경

### DIFF
--- a/backend/src/main/java/com/gdsc/backend/entity/enums/StateType.java
+++ b/backend/src/main/java/com/gdsc/backend/entity/enums/StateType.java
@@ -2,7 +2,8 @@ package com.gdsc.backend.entity.enums;
 
 public enum StateType {
     PREGNANT("Unmarried_pregnant"),
-    MOTHER("Unmarried_mother");
+    MOTHER("Unmarried_mother"),
+    FATHER("Unmarried_father");
 
     private String value;
 

--- a/backend/src/main/java/com/gdsc/backend/http/request/UpdateUserRequest.java
+++ b/backend/src/main/java/com/gdsc/backend/http/request/UpdateUserRequest.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UpdateUserRequest {
     public UpdateUserRequest(StateType stateType) {
         this.stateType = stateType;

--- a/backend/src/main/java/com/gdsc/backend/oauth2/jwt/Token.java
+++ b/backend/src/main/java/com/gdsc/backend/oauth2/jwt/Token.java
@@ -10,7 +10,6 @@ import lombok.ToString;
 @ToString
 @Getter
 @Builder
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Token {
     private String roleType;
     private String token;


### PR DESCRIPTION
# Description
기존 snake case를 사용했던 JSON 표기 방식에서 [Google JSON 스타일 가이드](https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format)에 따라 camel case로 변경합니다.

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [ ] JSON이 Camel Case로 표시되는지 확인합니다.